### PR TITLE
Optimized matrix-rendering

### DIFF
--- a/src/matrix_viz/core.clj
+++ b/src/matrix_viz/core.clj
@@ -38,10 +38,14 @@
     (m/eseq data)))
 
 (defn- mget
-  [data & args]
-  (if (t/tensor? data)
-    (apply t/mget data args)
-    (apply m/mget data args)))
+  ([data x0 x1]
+   (if (t/tensor? data)
+     (t/mget data x0 x1)
+     (m/mget data x0 x1)))
+  ([data x0 x1 x2 & args]
+   (if (t/tensor? data)
+     (apply t/mget data x0 x1 x2 args)
+     (apply m/mget data x0 x1 x2 args))))
 
 (defn- mset!
   [data & args]

--- a/src/matrix_viz/core.clj
+++ b/src/matrix_viz/core.clj
@@ -184,7 +184,8 @@
         image-width            (* cols pixels-per-cell)
         legend-color-height    (max 20 (quot image-height-no-legend 20))
         legend-text-height     (int (/ legend-color-height 1.5))
-        legend-padding         (quot legend-color-height 4)]
+        legend-padding         (quot legend-color-height 4)
+        v0                     (first (matrix-values nodata-value matrix))]
     {:rows                rows
      :cols                cols
      :image-height        (+ image-height-no-legend legend-color-height legend-text-height (* legend-padding 3))
@@ -193,8 +194,8 @@
      :legend-padding      legend-padding
      :legend-top          (+ image-height-no-legend legend-padding)
      :legend-width        (- image-width (* 2 legend-padding))
-     :legend-min          (reduce min (matrix-values nodata-value matrix))
-     :legend-max          (reduce max (matrix-values nodata-value matrix))}))
+     :legend-min          (reduce min v0 (matrix-values nodata-value matrix))
+     :legend-max          (reduce max v0 (matrix-values nodata-value matrix))}))
 
 (defn save-matrix-as-png
   "Renders the matrix as either an 8-bit grayscale image (color-ramp

--- a/src/matrix_viz/core.clj
+++ b/src/matrix_viz/core.clj
@@ -38,6 +38,11 @@
     (m/eseq data)))
 
 (defn- mget
+  ([data x0] data)
+  ([data x0]
+   (if (t/tensor? data)
+     (t/mget data x0)
+     (m/mget data x0)))
   ([data x0 x1]
    (if (t/tensor? data)
      (t/mget data x0 x1)

--- a/src/matrix_viz/core.clj
+++ b/src/matrix_viz/core.clj
@@ -171,6 +171,11 @@
       (.dispose))
     image))
 
+(defn- matrix-values
+  [nodata-value matrix]
+  (->> (eseq matrix)
+       (eduction (remove (fn [v] (= nodata-value v))))))
+
 (defn- make-image-parameters
   [matrix pixels-per-cell nodata-value]
   (let [rows                   (row-count matrix)
@@ -188,8 +193,8 @@
      :legend-padding      legend-padding
      :legend-top          (+ image-height-no-legend legend-padding)
      :legend-width        (- image-width (* 2 legend-padding))
-     :legend-min          (apply min (remove #{nodata-value} (eseq matrix)))
-     :legend-max          (apply max (remove #{nodata-value} (eseq matrix)))}))
+     :legend-min          (reduce min (matrix-values nodata-value matrix))
+     :legend-max          (reduce max (matrix-values nodata-value matrix))}))
 
 (defn save-matrix-as-png
   "Renders the matrix as either an 8-bit grayscale image (color-ramp

--- a/src/matrix_viz/core.clj
+++ b/src/matrix_viz/core.clj
@@ -38,7 +38,7 @@
     (m/eseq data)))
 
 (defn- mget
-  ([data x0] data)
+  ([data] data)
   ([data x0]
    (if (t/tensor? data)
      (t/mget data x0)


### PR DESCRIPTION
From my measurements, these 2 optimizations increase by 4x the efficiency of BufferedImage-generation in `matrix-viz.core/save-matrix-as-png`.

---
## Performance measurements

I measured on my laptop the performance of generating the BufferedImage of a 1600x1600 GridFire `:burn-time-matrix`. The evaluated expression looked like:

```clojure
(matrix-viz.core/matrix-to-buffered-image
              :color 1 -1.0
              (:burn-time-matrix matrices))
```

This 1st flame graph, made before the optimizations, shows that these were significant sources of overhead:
![01-cpu-flamegraph-2022-07-01-18-12-33](https://user-images.githubusercontent.com/5859120/177003095-98409105-9c3a-45d2-bddc-fa3cf0099644.svg)

Before optimizing, criterium-benchmarking yielded:

```
Evaluation count : 120 in 60 samples of 2 calls.
             Execution time mean : 1.006235 sec
    Execution time std-deviation : 30.846738 ms
   Execution time lower quantile : 984.665431 ms ( 2.5%)
   Execution time upper quantile : 1.074640 sec (97.5%)
                   Overhead used : 1.887161 ns
```

... and after optimizing:
```
Evaluation count : 240 in 60 samples of 4 calls.
             Execution time mean : 266.026682 ms
    Execution time std-deviation : 50.351484 ms
   Execution time lower quantile : 244.967024 ms ( 2.5%)
   Execution time upper quantile : 334.066427 ms (97.5%)
                   Overhead used : 1.884948 ns
```
 
Runtime details:

```
{:spec-vendor            "Oracle Corporation",
 :spec-name              "Java Virtual Machine Specification",
 :vm-version             "25.282-b08",
 :name                   "49196@robo",
 :clojure-version-string "1.10.3",
 :java-runtime-version   "1.8.0_282-b08",
 :java-version           "1.8.0_282",
 :vm-name                "OpenJDK 64-Bit Server VM",
 :vm-vendor              "AdoptOpenJDK",
 :clojure-version        {:major 1, :minor 10, :incremental 3, :qualifier nil},
 :spec-version           "1.8",
 :sun-arch-data-model    "64",
 :input-arguments        ["-Dclojure.libfile=/private/var/folders/62/3v4gckg15t706bjzkjw155n00000gq/T/libfile5.libs"
                          "-javaagent:/Applications/IntelliJ IDEA CE.app/Contents/lib/idea_rt.jar=61033:/Applications/IntelliJ IDEA CE.app/Contents/bin"
                          "-Dfile.encoding=UTF-8"]}
```

For completeness, here is the after-optimizing flame graph:
![02-cpu-flamegraph-2022-07-02-15-28-20](https://user-images.githubusercontent.com/5859120/177003436-4111268d-46e2-4dc4-803f-cff294a778cc.svg)


... and here is the PNG-encoded image:
![my-test-burn-matrix](https://user-images.githubusercontent.com/5859120/177003451-44239098-4997-4ad2-bb90-372dd3ec6080.png)


